### PR TITLE
connectivity: Configure additional TCP parameters

### DIFF
--- a/core/java/android/net/LinkProperties.java
+++ b/core/java/android/net/LinkProperties.java
@@ -57,6 +57,8 @@ public final class LinkProperties implements Parcelable {
     private int mMtu;
     // in the format "rmem_min,rmem_def,rmem_max,wmem_min,wmem_def,wmem_max"
     private String mTcpBufferSizes;
+    private int mTcpDelayedAckSegments = 1;
+    private int mTcpUserCfg = 0;
 
     private static final int MIN_MTU    = 68;
     private static final int MIN_MTU_V6 = 1280;
@@ -160,6 +162,8 @@ public final class LinkProperties implements Parcelable {
             }
             setMtu(source.getMtu());
             mTcpBufferSizes = source.mTcpBufferSizes;
+            mTcpDelayedAckSegments = source.mTcpDelayedAckSegments;
+            mTcpUserCfg = source.mTcpUserCfg;
         }
     }
 
@@ -443,6 +447,45 @@ public final class LinkProperties implements Parcelable {
         return mTcpBufferSizes;
     }
 
+    /**
+     * Number of full MSS to receive before Acking RFC2581
+     * @param segments The number of segments to receive
+     *
+     * @hide
+     */
+    public void setTcpDelayedAckSegments(int segments) {
+        mTcpDelayedAckSegments = segments;
+    }
+
+    /**
+     * Gets the number of segments before acking
+     *
+     * @hide
+     */
+    public int getTcpDelayedAckSegments() {
+        return mTcpDelayedAckSegments;
+    }
+
+    /**
+     * Sets the value for TCP usercfg
+     *
+     * @param value 0/1 currently to disable/enable
+     *
+     * @hide
+     */
+    public void setTcpUserCfg(int value) {
+        mTcpUserCfg = value;
+    }
+
+    /**
+     * Gets the value of TCP usercfg
+     *
+     * @hide
+     */
+    public int getTcpUserCfg() {
+        return mTcpUserCfg;
+    }
+
     private RouteInfo routeWithInterface(RouteInfo route) {
         return new RouteInfo(
             route.getDestination(),
@@ -603,6 +646,8 @@ public final class LinkProperties implements Parcelable {
         mStackedLinks.clear();
         mMtu = 0;
         mTcpBufferSizes = null;
+        mTcpDelayedAckSegments = 1;
+        mTcpUserCfg = 0;
     }
 
     /**

--- a/services/core/java/com/android/server/ConnectivityService.java
+++ b/services/core/java/com/android/server/ConnectivityService.java
@@ -248,6 +248,8 @@ public class ConnectivityService extends IConnectivityManager.Stub
     private INetworkPolicyManager mPolicyManager;
 
     private String mCurrentTcpBufferSizes;
+    private int mCurrentTcpDelayedAckSegments;
+    private int mCurrentTcpUserCfg;
 
     private static final int ENABLED  = 1;
     private static final int DISABLED = 0;
@@ -1893,6 +1895,34 @@ public class ConnectivityService extends IConnectivityManager.Stub
         }
     }
 
+    private void updateTcpDelayedAck(NetworkAgentInfo nai) {
+        if (isDefaultNetwork(nai) == false) {
+            return;
+        }
+
+        int segments = nai.linkProperties.getTcpDelayedAckSegments();
+        int usercfg = nai.linkProperties.getTcpUserCfg();
+
+        if (segments != mCurrentTcpDelayedAckSegments) {
+            try {
+                FileUtils.stringToFile("/sys/kernel/ipv4/tcp_delack_seg",
+                        String.valueOf(segments));
+                mCurrentTcpDelayedAckSegments = segments;
+            } catch (IOException e) {
+                // optional
+            }
+        }
+
+        if (usercfg != mCurrentTcpUserCfg) {
+            try {
+                FileUtils.stringToFile("/sys/kernel/ipv4/tcp_use_usercfg",
+                        String.valueOf(usercfg));
+                mCurrentTcpUserCfg = usercfg;
+            } catch (IOException e) {
+                // optional
+            }
+        }
+    }
     private void flushVmDnsCache() {
         /*
          * Tell the VMs to toss their DNS caches
@@ -4444,6 +4474,7 @@ public class ConnectivityService extends IConnectivityManager.Stub
 //            updateMtu(lp, null);
 //        }
         updateTcpBufferSizes(networkAgent);
+        updateTcpDelayedAck(networkAgent);
 
         updateRoutes(newLp, oldLp, netId);
         updateDnses(newLp, oldLp, netId);
@@ -4760,6 +4791,7 @@ public class ConnectivityService extends IConnectivityManager.Stub
         notifyLockdownVpn(newNetwork);
         handleApplyDefaultProxy(newNetwork.linkProperties.getHttpProxy());
         updateTcpBufferSizes(newNetwork);
+        updateTcpDelayedAck(newNetwork);
         setDefaultDnsSystemProperties(newNetwork.linkProperties.getDnsServers());
     }
 


### PR DESCRIPTION
 * Add support for configuring TCP delayed ack segments / usercfg
   via LinkProperties. This can improve performance for usecases
   like WiFI display.

Change-Id: Iaf1fa7610a035ff91317544a8fc2e3f895831ad4