### PR TITLE
Fixed NPE in canAddMoreManagedProfiles

### DIFF
--- a/services/core/java/com/android/server/pm/UserManagerService.java
+++ b/services/core/java/com/android/server/pm/UserManagerService.java
@@ -1469,7 +1469,7 @@ public class UserManagerService extends IUserManager.Stub {
         }
         synchronized(mUsersLock) {
             UserInfo userInfo = getUserInfoLU(userId);
-            if (!userInfo.canHaveProfile()) {
+            if (userInfo == null || !userInfo.canHaveProfile()) {
                 return false;
             }
             int usersCountAfterRemoving = getAliveUsersExcludingGuestsCountLU()


### PR DESCRIPTION
We can use the command 'adb shell pm create-user --profileOf -10000
--managed TestProfile_12345678' to reproduce the problem.

Change-Id: I004ef8dd2aee4e911c292ddf85422a22ecbecd15