### PR TITLE
Allow to ignore presentation indicator of outgoing calls [1/3]

### DIFF
--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -9230,6 +9230,13 @@ public final class Settings {
         public static final String DATABASE_DOWNGRADE_REASON = "database_downgrade_reason";
 
         /**
+         * Whether to ignore the representation of outgoing calls set by the network.
+         *
+         * @hide
+         */
+         public static final String CONNECTED_LINE_IDENTIFICATION = "connected_line_identification";
+
+        /**
          * Settings to backup. This is here so that it's in the same place as the settings
          * keys and easy to update.
          *


### PR DESCRIPTION
With some mobile network operators, the presentation indicator of
outgoing calls is always set to either "unknown" or "restricted".
As consequence, the dialed number doesn't show up in clear in the
call history. Allow to ignore the presentation indicator of outgoing
calls to never hide the dialed numbers.

Change-Id: Ia40de2ce40fee5068f82abd69595b34d2596caae